### PR TITLE
Ignore Gemfile.lock in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,7 @@
 /spec/reports/
 /tmp/
 
+Gemfile.lock
+
 # rspec failure tracking
 .rspec_status


### PR DESCRIPTION
## Why

https://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/

> When developing a gem, use the gemspec method in your Gemfile to avoid duplication. In general, a gem's Gemfile should contain the Rubygems source and a single gemspec line. Do not check your Gemfile.lock into version control, since it enforces precision that does not exist in the gem command, which is used to install gems in practice. Even if the precision could be enforced, you wouldn't want it, since it would prevent people from using your library with versions of its dependencies that are different from the ones you used to develop the gem.

## What 

Ignore `Gemfile.lock`