### PR TITLE
Make build successful

### DIFF
--- a/lib/istio/tracing.rb
+++ b/lib/istio/tracing.rb
@@ -1,4 +1,4 @@
-require "tracing/context"
-require "tracing/header"
-require "tracing/http"
-require "tracing/rack"
+require "istio/tracing/context"
+require "istio/tracing/header"
+require "istio/tracing/http"
+require "istio/tracing/rack"

--- a/spec/istio_spec.rb
+++ b/spec/istio_spec.rb
@@ -2,8 +2,4 @@ RSpec.describe Istio do
   it "has a version number" do
     expect(Istio::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end


### PR DESCRIPTION
##  Why

To fix failing builds on master due to require..

## What

- Cherry-picked the fix for require from https://github.com/wantedly/istio-ruby/pull/3
- Remove a placeholder spec, which always fails